### PR TITLE
Ensure every transaction is named after the Ctrl+action

### DIFF
--- a/lib/newrelic-praxis/instrumentation/praxis.rb
+++ b/lib/newrelic-praxis/instrumentation/praxis.rb
@@ -15,8 +15,10 @@ DependencyDetection.defer do
 
   executes do
     require 'newrelic-praxis/praxis/action_event'
+    require 'newrelic-praxis/praxis/request_subscriber'
     require 'newrelic-praxis/praxis/action_subscriber'
 
+    NewRelic::Agent::Instrumentation::Praxis::RequestSubscriber.subscribe 'praxis.request.all'.freeze
     NewRelic::Agent::Instrumentation::Praxis::ActionSubscriber.subscribe 'praxis.request_stage.execute'.freeze
   end
 end

--- a/lib/newrelic-praxis/praxis/request_subscriber.rb
+++ b/lib/newrelic-praxis/praxis/request_subscriber.rb
@@ -1,0 +1,26 @@
+module NewRelic
+  module Agent
+    module Instrumentation
+      module Praxis
+
+        class RequestSubscriber < EventedSubscriber
+
+          def start(name, id, payload) #THREAD_LOCAL_ACCESS
+
+            action = payload[:request].action
+            controller = action.resource_definition.controller
+            metric_name = "Controller/#{controller.name}/#{action.name}"
+            current = NewRelic::Agent::Transaction.tl_current
+            current.set_overriding_transaction_name(metric_name, nil)
+          rescue => e
+            log_notification_error(e, name, 'start')
+          end
+
+          def finish(name, id, payload)
+          end
+
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
Ensure every transaction is named after the Ctrl+action:
- add a subscriber to praxis.request.all to ensure the override_name of the overall transaction is set to Ctrl#action

Signed-off-by: Josep M. Blanquer blanquer@rightscale.com
